### PR TITLE
Update to Threeten-Extra 1.1 and added support for Seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following type handlers are supported:
 | ------------ | ------------------- | ---------- |
 | `DayOfMonthTypeHandler` | `org.threeten.extra.DayOfMonth` | `INTEGER` |
 | `DayOfYearTypeHandler` | `org.threeten.extra.DayOfYear` | `INTEGER` |
+| `SecondsTypeHandler` | `org.threeten.extra.Seconds` | `INTEGER` |
 | `MinutesTypeHandler` | `org.threeten.extra.Minutes` | `INTEGER` |
 | `HoursTypeHandler` | `org.threeten.extra.Hours` | `INTEGER` |
 | `DaysTypeHandler` | `org.threeten.extra.Days` | `INTEGER` |

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.threeten</groupId>
       <artifactId>threeten-extra</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/org/mybatis/typehandlers/threetenextra/SecondsTypeHandler.java
+++ b/src/main/java/org/mybatis/typehandlers/threetenextra/SecondsTypeHandler.java
@@ -1,0 +1,56 @@
+/**
+ *    Copyright 2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.typehandlers.threetenextra;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.threeten.extra.Seconds;
+
+/**
+ * Type handler for ThreeTen-Extra's {@link Seconds}.
+ * 
+ * @author Björn Raupach
+ */
+public class SecondsTypeHandler extends BaseTypeHandler<Seconds> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int parameterIndex, Seconds seconds, JdbcType type) throws SQLException {
+        ps.setInt(parameterIndex, seconds.getAmount());
+    }
+
+    @Override
+    public Seconds getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        int seconds = rs.getInt(columnName);
+        return rs.wasNull() ? null : Seconds.of(seconds);
+    }
+
+    @Override
+    public Seconds getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        int seconds = rs.getInt(columnIndex);
+        return rs.wasNull() ? null : Seconds.of(seconds);
+    }
+
+    @Override
+    public Seconds getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        int seconds = cs.getInt(columnIndex);
+        return cs.wasNull() ? null : Seconds.of(seconds);
+    }
+    
+}

--- a/src/test/java/org/mybatis/typehandlers/threetenextra/SecondsTypeHandlerTest.java
+++ b/src/test/java/org/mybatis/typehandlers/threetenextra/SecondsTypeHandlerTest.java
@@ -1,0 +1,86 @@
+/**
+ *    Copyright 2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.typehandlers.threetenextra;
+
+import org.apache.ibatis.type.TypeHandler;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.threeten.extra.Seconds;
+
+/**
+ *
+ * @author Björn Raupach
+ */
+public class SecondsTypeHandlerTest extends BaseTypeHandlerTest {
+    
+    private static final TypeHandler<Seconds> TYPE_HANDLER = new SecondsTypeHandler();
+    private static final Seconds SECONDS = Seconds.ZERO;
+
+    @Override
+    @Test
+    public void shouldSetParameter() throws Exception {
+        TYPE_HANDLER.setParameter(ps, 1, SECONDS, null);
+        verify(ps).setInt(1, SECONDS.getAmount());
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(SECONDS.getAmount());
+        assertThat(TYPE_HANDLER.getResult(rs, "column")).isEqualTo(SECONDS);
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertThat(TYPE_HANDLER.getResult(rs, "column")).isNull();
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(SECONDS.getAmount());
+        assertThat(TYPE_HANDLER.getResult(rs, 1)).isEqualTo(SECONDS);
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertThat(TYPE_HANDLER.getResult(rs, 1)).isNull();
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(SECONDS.getAmount());
+        assertThat(TYPE_HANDLER.getResult(cs, 1)).isEqualTo(SECONDS);
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(0);
+        when(cs.wasNull()).thenReturn(true);
+        assertThat(TYPE_HANDLER.getResult(cs, 1)).isNull();
+    }
+    
+}


### PR DESCRIPTION
Hello community,

[ThreeTen-Extra 1.1](http://www.threeten.org/threeten-extra/changes-report.html#a1.1) was released yesterday.

It features another temporal amount class: Seconds

The TypeHandler and Unit tests are enclosed.